### PR TITLE
Handle unexpected turbopack error

### DIFF
--- a/latvian-cv-maker/package.json
+++ b/latvian-cv-maker/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack -p ${PORT:-3002}",
+    "dev": "next dev -p ${PORT:-3002}",
     "dev:custom": "./scripts/dev.sh",
-    "build": "next build --turbopack",
+    "build": "next build",
     "start": "next start -p ${PORT:-3002}",
     "start:tmux": "./start.sh",
     "stop": "./start.sh --kill",


### PR DESCRIPTION
Remove `--turbopack` flag from `dev` and `build` scripts to resolve a Turbopack error with internationalized routing.

Turbopack currently has known issues handling Next.js internationalized routing (`[locale]` dynamic segments), leading to the error "Failed to write app endpoint /[locale]/page". Disabling Turbopack forces Next.js to use the stable webpack bundler, which resolves this conflict.

---
<a href="https://cursor.com/background-agent?bcId=bc-d7bb8af1-aafd-48a8-878e-d42e3b81e62b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d7bb8af1-aafd-48a8-878e-d42e3b81e62b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

